### PR TITLE
Fix IcoMoonFree SVG directory

### DIFF
--- a/build/src/package/mod.rs
+++ b/build/src/package/mod.rs
@@ -434,7 +434,7 @@ impl PackageType {
                     },
                 },
                 download_dir: Cow::Borrowed("icomoon-free"),
-                svg_dir: Cow::Borrowed("svg"),
+                svg_dir: Cow::Borrowed("SVG"),
                 crate_version: SemVer {
                     major: 0,
                     minor: 0,


### PR DESCRIPTION
Not sure why this icon folder is lowercased, but should be uppercased. See https://github.com/Keyamoon/IcoMoon-Free/tree/d006795ede82361e1bac1ee76f215cf1dc51e4ca Perhaps you're developing on a OS with case insensitive filesystem?

This is breaking my build locally on Ubuntu. 
